### PR TITLE
Added option to define series names as a prefix to group by values

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -60,6 +60,13 @@ export class QueryEditor extends PureComponent<Props, QueryEditorState> {
     onRunQuery();
   };
 
+  onChangeSeriesName = (evt: React.FormEvent<HTMLInputElement>) => {
+    const { onChange, onRunQuery, query } = this.props;
+
+    onChange({ ...query, seriesName: evt.currentTarget.value || '' });
+    onRunQuery();
+  };
+
   onProjectSelectionChange = ({ value }: SelectableValue) => {
     const { onChange, onRunQuery, query } = this.props;
 
@@ -123,6 +130,15 @@ export class QueryEditor extends PureComponent<Props, QueryEditorState> {
                 spellCheck="false"
                 onChange={this.onChangeFormat}
                 value={this.props.query.format}
+              />
+            </Field>
+            <Field label="Series name" description="Series name to use as prefix to series group by values">
+              <Input
+                css
+                name="seriesName"
+                spellCheck="false"
+                onChange={this.onChangeSeriesName}
+                value={this.props.query.seriesName}
               />
             </Field>
           </Collapse>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface LightstepQuery extends DataQuery {
   text: string;
   format: string;
   language: LightstepQueryLanguage;
+  seriesName: string;
 }
 
 export function defaultQuery(projectName: string): Partial<LightstepQuery> {


### PR DESCRIPTION
Implementation for https://github.com/lightstep/lightstep-observability-datasource/issues/7

![image](https://user-images.githubusercontent.com/29553198/225048555-412aaea0-d188-4149-9a3e-650eb86e109f.png)
