### PR TITLE
Enforce 1sec minimum output period

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -59,7 +59,8 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
               'input-language': query.language,
               'oldest-time': request.range.from,
               'youngest-time': request.range.to,
-              'output-period': rangeUtil.intervalToSeconds(request.interval),
+              // query_timeseries minimum supported output-period is 1 second
+              'output-period': Math.max(1, rangeUtil.intervalToSeconds(request.interval)),
             },
             analytics: {
               anonymized_user: hashedEmail,


### PR DESCRIPTION
This PR resolves an issue where queries of the last 15min or less will currently fail because the output period for them is less than 1 second:

<img width="1307" alt="Screenshot 2023-06-30 at 6 04 05 AM" src="https://github.com/lightstep/servicenow-cloud-observability-datasource/assets/8461733/63cd34eb-94bb-4aaf-b4de-45e63273f790">

A 1sec minimum output period is now required:

<img width="1304" alt="Screenshot 2023-06-30 at 6 10 04 AM" src="https://github.com/lightstep/servicenow-cloud-observability-datasource/assets/8461733/616ce774-dccb-4ff5-9172-98fb77eeb955">
