### PR TITLE
Improve plugin marketplace searchability

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -5,7 +5,7 @@
   "id": "servicenow-cloudobservability-datasource",
   "metrics": true,
   "info": {
-    "description": "Instantly visualize ServiceNow Cloud Observability data in Grafana",
+    "description": "Instantly visualize ServiceNow Cloud Observability (formerly known as Lightstep) data in Grafana",
     "author": {
       "name": "ServiceNow Cloud Observability",
       "url": "https://www.servicenow.com/products/observability.html"
@@ -25,12 +25,7 @@
         "url": "https://github.com/lightstep/servicenow-cloud-observability-datasource"
       }
     ],
-    "screenshots": [
-      {
-        "name": "overview",
-        "path": "img/grafana_dashboard_overview.png"
-      }
-    ],
+    "screenshots": [],
     "version": "%VERSION%",
     "updated": "%TODAY%"
   },


### PR DESCRIPTION
## What does this PR do?

Improves the Grafana plugin marketplace listing searchability.

## How does this impact users?

It's now possible to find the plugin searching either "Lightstep" or "ServiceNow"

## What needed to change in the code and why?

plugin.json description info updated.

## How did you test this?

Not tested

## Code review notes

None
