### PR TITLE
Add experimental logs query support

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,6 +3,7 @@
   "type": "datasource",
   "name": "ServiceNow Cloud Observability",
   "id": "servicenow-cloudobservability-datasource",
+  "logs": true,
   "metrics": true,
   "info": {
     "description": "Instantly visualize ServiceNow Cloud Observability (formerly known as Lightstep) data in Grafana",

--- a/src/preprocessors/__snapshots__/index.test.js.snap
+++ b/src/preprocessors/__snapshots__/index.test.js.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`preprocesses logs successfully 1`] = `
+Object {
+  "fields": Array [
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "time",
+      "type": "time",
+      "values": Array [
+        1691409972788,
+        1691409971908,
+      ],
+    },
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "content",
+      "type": "string",
+      "values": Array [
+        "one",
+        "two",
+      ],
+    },
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "level",
+      "type": "string",
+      "values": Array [
+        "error",
+        "info",
+      ],
+    },
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "severity",
+      "type": "string",
+      "values": Array [
+        "ErrorSeverity",
+        "InfoSeverity",
+      ],
+    },
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "http.status_code",
+      "type": "number",
+      "values": Array [
+        200,
+        undefined,
+      ],
+    },
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "large_batch",
+      "type": "boolean",
+      "values": Array [
+        true,
+        false,
+      ],
+    },
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "trace_id",
+      "type": "string",
+      "values": Array [
+        "d29a3fa8fb446ec65eb691a3259a541e",
+        "d0fa420269652931236c94bc54d2233e",
+      ],
+    },
+    Object {
+      "config": Object {},
+      "labels": undefined,
+      "name": "customer",
+      "type": "string",
+      "values": Array [
+        undefined,
+        "hipcore",
+      ],
+    },
+  ],
+  "meta": Object {
+    "preferredVisualisationType": "logs",
+  },
+  "name": undefined,
+  "refId": "a",
+}
+`;

--- a/src/preprocessors/index.test.js
+++ b/src/preprocessors/index.test.js
@@ -1,0 +1,42 @@
+import { preprocessData } from './index';
+
+test('preprocesses logs successfully', () => {
+  const logsDataFrame = preprocessData(
+    {
+      data: {
+        attributes: {
+          logs: [
+            [
+              1691409972788,
+              {
+                event: 'one',
+                severity: 'ErrorSeverity',
+                tags: {
+                  'http.status_code': 200,
+                  large_batch: true,
+                  trace_id: 'd29a3fa8fb446ec65eb691a3259a541e',
+                },
+              },
+            ],
+            [
+              1691409971908,
+              {
+                event: 'two',
+                severity: 'InfoSeverity',
+                tags: {
+                  customer: 'hipcore',
+                  large_batch: false,
+                  trace_id: 'd0fa420269652931236c94bc54d2233e',
+                },
+              },
+            ],
+          ],
+        },
+      },
+    },
+    { refId: 'a' },
+    ''
+  );
+
+  expect(logsDataFrame.toJSON()).toMatchSnapshot();
+});

--- a/src/preprocessors/index.ts
+++ b/src/preprocessors/index.ts
@@ -1,10 +1,19 @@
 import { DataFrame } from '@grafana/data';
-import { LightstepQuery, QueryRes } from '../types';
+import { LightstepQuery, QueryLogsRes, QueryRes } from '../types';
+import { preprocessLogs } from './logs';
 import { preprocessTimeseries } from './timeseries';
 
 /**
  * Preprocessor entry point routes responses to the correct preprocessor
  */
 export function preprocessData(res: QueryRes, query: LightstepQuery, notebookURL: string): DataFrame {
-  return preprocessTimeseries(res, query, notebookURL);
+  if (isLogsRes(res)) {
+    return preprocessLogs(res, query);
+  } else {
+    return preprocessTimeseries(res, query, notebookURL);
+  }
+}
+
+function isLogsRes(res: QueryRes): res is QueryLogsRes {
+  return 'logs' in res.data.attributes;
 }

--- a/src/preprocessors/logs.ts
+++ b/src/preprocessors/logs.ts
@@ -1,0 +1,92 @@
+import { MutableDataFrame, FieldType } from '@grafana/data';
+import { LightstepQuery, QueryLogsRes } from 'types';
+
+/**
+ * Response pre-processor that converts the LS response data into Grafana wide
+ * data frames, eg:
+ *
+ * **Lightstep API response shape**
+ * ```json
+ * {
+ *   "query": {
+ *     "data": {
+ *       "attributes": {
+ *         "logs": [
+ *           [1691409972788, { event: "one", severity: "ErrorSeverity", tags: { ... } }],
+ *           [1691409971908, { event: "two", severity: "InfoSeverity", tags: { ... } }]
+ *         ]
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * **Grafana DataFrame shape**
+ * ```js
+ * [
+ *   { name: 'time', type: FieldType.time, values: [0, 1, 2] },
+ *   { name: 'content', type: FieldType.string, values: ["one", "two"] },
+ *   { name: 'level', type: FieldType.string, values: ["error", "info"] }
+ * ]
+ * ```
+ */
+export function preprocessLogs(res: QueryLogsRes, query: LightstepQuery) {
+  /** Map of "detected fields" aka log tags that have been added to the data frame */
+  const detectedFields = new Map<string, boolean>();
+
+  const frame = new MutableDataFrame({
+    refId: query.refId,
+    meta: {
+      preferredVisualisationType: 'logs',
+    },
+    fields: [
+      { name: 'time', type: FieldType.time },
+      { name: 'content', type: FieldType.string },
+      { name: 'level', type: FieldType.string },
+      { name: 'severity', type: FieldType.string },
+    ],
+  });
+
+  res.data.attributes.logs.forEach(([timestamp, log]) => {
+    Object.entries(log.tags).forEach(([key, value]) => {
+      // Add every log tag to the set of detected fields once
+      if (!detectedFields.has(key)) {
+        detectedFields.set(key, true);
+        frame.addField({
+          name: key,
+          type: getFieldTypeForValue(value),
+        });
+      }
+    });
+
+    frame.add({
+      time: timestamp,
+      content: log.event,
+      level: SEVERITY_MAP[log.severity],
+      severity: log.severity,
+      ...log.tags,
+    });
+  });
+
+  return frame;
+}
+
+/** @ref https://grafana.com/docs/grafana/latest/explore/logs-integration/ */
+const SEVERITY_MAP = {
+  InfoSeverity: 'info',
+  ErrorSeverity: 'error',
+  WarningSeverity: 'warning',
+};
+
+function getFieldTypeForValue(value: unknown): FieldType {
+  switch (typeof value) {
+    case 'string':
+      return FieldType.string;
+    case 'number':
+      return FieldType.number;
+    case 'boolean':
+      return FieldType.boolean;
+    default:
+      return FieldType.other;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,14 +62,9 @@ export interface QueryLogsRes {
       logs: Array<
         [
           timestamp: number,
-          event: {
-            /** internal timestamp */
-            _ts: number;
-            observed_time: number;
-            severity: 'InfoSeverity' | 'WarningSeverity' | 'ErrorSeverity';
-            event: string;
-            tags: Record<string, string | number | boolean>;
-            _lid: number;
+          /** nb: log fields do not have a formal schema */
+          log: {
+            [key: string]: unknown;
           }
         ]
       >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,17 +33,46 @@ export interface LightstepSecureJsonData {
 // --------------------------------------------------------
 // DATA SHAPES
 
-export type QueryRes = QueryTimeseriesRes;
+export type QueryRes = QueryLogsRes | QueryTimeseriesRes;
 
+/**
+ * Response shape for a timeseries query
+ * @example metric requests | rate | group_by [customer], sum
+ */
 export interface QueryTimeseriesRes {
   data: {
     attributes: {
       series: Array<{
         'group-labels': string[];
-        points: Point[];
+        /** Array of timestamp, value tuples */
+        points: Array<[timestamp: number, value: number]>;
       }>;
     };
   };
 }
 
-type Point = [timestamp: number, value: number];
+/**
+ * Response shape for a logs query.
+ * @example logs | filter tags.customer == "name"
+ */
+export interface QueryLogsRes {
+  data: {
+    attributes: {
+      /** Array of timestamp, event tuples */
+      logs: Array<
+        [
+          timestamp: number,
+          event: {
+            /** internal timestamp */
+            _ts: number;
+            observed_time: number;
+            severity: 'InfoSeverity' | 'WarningSeverity' | 'ErrorSeverity';
+            event: string;
+            tags: Record<string, string | number | boolean>;
+            _lid: number;
+          }
+        ]
+      >;
+    };
+  };
+}


### PR DESCRIPTION
## What does this PR do?

Adds support for the upcoming Logs in ServiceNow Cloud Observability release by supporting log data responses in the plugin.

Once released, log queries sent to the datasource endpoint will return a set of log events matching the `QueryLogsRes`. The plugin will check the res for this field and prepocess with the new logs preprocessor if found.

<img width="1728" alt="Screenshot 2023-08-07 at 5 35 55 AM" src="https://github.com/lightstep/servicenow-cloud-observability-datasource/assets/8461733/b66dccf5-2c8c-4fd1-941d-c96495d0c670">


## How does this impact users?

Once available, users with logs data in Cloud Observability will be able to write logs queries and get back logs data that can be included in dashboards with the logs panel 🎉 

## What needed to change in the code and why?

The preprocessor entry now checks the res for a top level switch between `data.attributes.series` and `data.attributes.logs` to route the res to the correct preprocessor.

## How did you test this?

Unit test that the top level preprocessor returns the correct data frame shape is added.

## Code review notes

The log event object is defined as an object of unknown key:value pairs - this is intended to reflect the non-structured schema of the log event.