### PR TITLE
Fix: replace whitespace before splitting project names

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -125,7 +125,9 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
 
   /** Return the set of configured project names for data source */
   projects(): string[] {
-    return this.projectName.split(',');
+    // nb string replace removes optional whitespace between project names, eg:
+    // "dev, pre-prod, prod" -> ["dev", "pre-prod", "prod"]
+    return this.projectName.replace(/\s/g, '').split(',');
   }
 
   /** Returns the first configured project name for data source */


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where datasources with multiple projects must be configured without any spaces, eg this is project configuration would fail: `dev, pre-prod, prod` (it would currently have to be configured as `dev,pre-prod,prod`.

## How does this impact users?

Enables more intuitive configuration of the datasource by gracefully handling a common pattern.

## What needed to change in the code and why?

Remove whitespace from configuration value before splitting project names.

## How did you test this?

Local development testing.

## Code review notes

None.
