### PR TITLE
Update query project when switching datasources

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -18,6 +18,21 @@ export class QueryEditor extends PureComponent<Props, State> {
     isOptionsOpen: false,
   };
 
+  componentDidMount(): void {
+    const { query, datasource, onChange, onRunQuery } = this.props;
+    const projects = datasource.projects();
+
+    // onMount the editor must validate the configured query projectName is part
+    // of the configured datasource's configured projects
+    // nb: This is a required check for users with multiple instances of the
+    // plugin installed, switching between them needs to also update the query
+    // project name value
+    if (!projects.includes(query.projectName)) {
+      onChange({ ...query, projectName: datasource.defaultProjectName() });
+      onRunQuery();
+    }
+  }
+
   onQueryChange = (value: string) => {
     const { onChange, query } = this.props;
 
@@ -31,23 +46,6 @@ export class QueryEditor extends PureComponent<Props, State> {
     onChange({ ...query, format: evt.currentTarget.value || '' });
     onRunQuery();
   };
-
-  /**
-   * onMount responsibilities:
-   * - When the QueryEditor mounts it should check if there is an existing
-   *   query, and if there is that it has a valid project selected. This is
-   *   important if the user has multiple instances of the plugin installed, in
-   *   that case switching between them also needs to update the query project
-   */
-  componentDidMount(): void {
-    const { query, datasource, onChange, onRunQuery } = this.props;
-    const projects = datasource.projects();
-
-    if (!projects.includes(query.projectName)) {
-      onChange({ ...query, projectName: datasource.defaultProjectName() });
-      onRunQuery();
-    }
-  }
 
   onProjectSelectionChange = ({ value }: SelectableValue) => {
     const { onChange, onRunQuery, query } = this.props;

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -32,6 +32,23 @@ export class QueryEditor extends PureComponent<Props, State> {
     onRunQuery();
   };
 
+  /**
+   * onMount responsibilities:
+   * - When the QueryEditor mounts it should check if there is an existing
+   *   query, and if there is that it has a valid project selected. This is
+   *   important if the user has multiple instances of the plugin installed, in
+   *   that case switching between them also needs to update the query project
+   */
+  componentDidMount(): void {
+    const { query, datasource, onChange, onRunQuery } = this.props;
+    const projects = datasource.projects();
+
+    if (!projects.includes(query.projectName)) {
+      onChange({ ...query, projectName: datasource.defaultProjectName() });
+      onRunQuery();
+    }
+  }
+
   onProjectSelectionChange = ({ value }: SelectableValue) => {
     const { onChange, onRunQuery, query } = this.props;
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -37,10 +37,11 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
   async query(request: DataQueryRequest<LightstepQuery>): Promise<DataQueryResponse> {
     try {
       const hashedEmail = await hashEmail(config.bootData.user.email);
+      const projects = this.projects();
 
       // All queries _should_ have a project name, this decoration _ensures_ it
       request.targets.forEach((target) => {
-        if (!target.projectName) {
+        if (!target.projectName || !projects.includes(target.projectName)) {
           target.projectName = this.defaultProjectName();
         }
       });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -39,9 +39,11 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
       const hashedEmail = await hashEmail(config.bootData.user.email);
       const projects = this.projects();
 
-      // All queries _should_ have a project name, this decoration _ensures_ it
+      // Project name check: Ensure that every query has a projectName defined, and that
+      // the defined value is in the current datasource's configured set of projects.
+      // nb: This is a required check when users have setup a datasource template variable
       request.targets.forEach((target) => {
-        if (!target.projectName || !projects.includes(target.projectName)) {
+        if (!projects.includes(target.projectName)) {
           target.projectName = this.defaultProjectName();
         }
       });


### PR DESCRIPTION
## What does this PR do?

Adds checks that the configured query projectName matches the current datasource instance projectName configuration. This resolves two current issues:

1. Switching between instances of the plugin when editing a query currently fails to update the query's project name to match.
2. Using a template variable for the query datasource currently fails to update the query's project name to match.

Closes #33 

## How does this impact users?

Enables users to install multiple copies of the plugin with different projects configured for each copy. These copies of the plugin can then be used in a dashboard template variable, or to simplify switching between projects in the editor query mode by treating them as different datasources.

## What needed to change in the code and why?

Checks on the query projectName were added to the query editor and the datasource `request` handler because the datasource project name can change without the query itself changing.

## How did you test this?

Locally tested using a template variable setup.

## Code review notes

_none_
