### PR TITLE
Fix: Early return if there are no queries to make

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -50,6 +50,9 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
 
       // Only make requests for non-empty, non-hidden queries
       const visibleTargets = request.targets.filter((query) => query.text && !query.hide);
+      if (visibleTargets.length === 0) {
+        return { data: [] };
+      }
 
       const projectName = visibleTargets[0].projectName;
       const notebookURL = createNotebookURL(request, visibleTargets, projectName);


### PR DESCRIPTION
## What does this PR do?

Small fix to return early from the `query` hook if there are no queries to make. Fixes a minor bug where a new empty chart shows this projectName of undefined error:

<img width="1315" alt="Screenshot 2023-12-06 at 9 05 28 AM" src="https://github.com/lightstep/servicenow-cloud-observability-datasource/assets/8461733/0a2899d1-4bf0-4a90-8f9f-186574ae71fb">


## How does this impact users?

When creating a new chart there is no longer a confusing error state.

## What needed to change in the code and why?

Check if there are visible queries to make a request for, and if not return early.
