### PR TITLE
BREAKING: Update minimum supported Grafana version to 8.4.7

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -36,7 +36,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=7.2.0",
+    "grafanaDependency": ">=8.4.7",
     "plugins": []
   },
   "routes": [


### PR DESCRIPTION
## What does this PR do?

Updates the minimum supported Grafana version from the current `7.2.0` to `8.4.7`
