### PR TITLE
Update test datasource URL 

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -110,7 +110,7 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
     }
 
     try {
-      await getBackendSrv().get(`${this.url}/test`);
+      await getBackendSrv().get(`${this.url}/projects/${this.defaultProjectName()}`);
       return {
         status: 'success',
         message: 'Data source is working',


### PR DESCRIPTION
## What does this PR do?

Switches the `testDatasource` url to use the GetProject endpoint

## How does this impact users?

Currently, project specific tokens are being rejected as invalid since the `/test` endpoint is org specific and doesn't include project details.

## What needed to change in the code and why?
Changed the test url to query the GetProject endpoint with a specific project. This allows Org and Project specific tokens to test and check validity.


## How did you test this?

Manual testing

## Code review notes

<!-- Any miscellaneous notes that would help the the reviewer -->
