### PR TITLE
Allow templated legend via attribute keys and values from query results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "servicenow-cloudobservability-datasource",
-  "version": "3.4.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "servicenow-cloudobservability-datasource",
-      "version": "3.4.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "6.3.2",
@@ -22,6 +22,7 @@
         "@lezer/common": "1.1.1",
         "@lezer/highlight": "1.2.0",
         "@lezer/lr": "1.3.14",
+        "lodash": "^4.17.21",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tslib": "2.5.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@lezer/common": "1.1.1",
         "@lezer/highlight": "1.2.0",
         "@lezer/lr": "1.3.14",
-        "lodash": "^4.17.21",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tslib": "2.5.3"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@lezer/common": "1.1.1",
     "@lezer/highlight": "1.2.0",
     "@lezer/lr": "1.3.14",
+    "lodash": "^4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tslib": "2.5.3"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@lezer/common": "1.1.1",
     "@lezer/highlight": "1.2.0",
     "@lezer/lr": "1.3.14",
-    "lodash": "^4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tslib": "2.5.3"

--- a/src/preprocessors/__snapshots__/index.test.js.snap
+++ b/src/preprocessors/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`preprocesses logs successfully 1`] = `
+exports[`logs preprocesses successfully 1`] = `
 {
   "fields": [
     {
@@ -89,5 +89,70 @@ exports[`preprocesses logs successfully 1`] = `
   },
   "name": undefined,
   "refId": "a",
+}
+`;
+
+exports[`preprocesses Timeseries successfully should set displayNameDS with legend formatter 1`] = `
+{
+  "fields": [
+    {
+      "config": {},
+      "labels": undefined,
+      "name": "Time",
+      "type": "time",
+      "values": [
+        0,
+        1,
+        2,
+      ],
+    },
+    {
+      "config": {
+        "displayNameFromDS": "/get",
+        "links": [
+          {
+            "targetBlank": true,
+            "title": "Create a Notebook in Lightstep",
+            "url": "https://notebooks",
+          },
+        ],
+      },
+      "labels": {
+        "operation": "/get",
+      },
+      "name": "Value",
+      "type": "number",
+      "values": [
+        1,
+        7,
+        1,
+      ],
+    },
+    {
+      "config": {
+        "displayNameFromDS": "/load",
+        "links": [
+          {
+            "targetBlank": true,
+            "title": "Create a Notebook in Lightstep",
+            "url": "https://notebooks",
+          },
+        ],
+      },
+      "labels": {
+        "operation": "/load",
+      },
+      "name": "Value",
+      "type": "number",
+      "values": [
+        6,
+        5,
+        9,
+      ],
+    },
+  ],
+  "meta": undefined,
+  "name": undefined,
+  "refId": undefined,
 }
 `;

--- a/src/preprocessors/__snapshots__/index.test.js.snap
+++ b/src/preprocessors/__snapshots__/index.test.js.snap
@@ -197,3 +197,44 @@ exports[`preprocesses Timeseries successfully should work if there are no labels
   "refId": undefined,
 }
 `;
+
+exports[`preprocesses Timeseries successfully should work if there are no labels and no legend 1`] = `
+{
+  "fields": [
+    {
+      "config": {},
+      "labels": undefined,
+      "name": "Time",
+      "type": "time",
+      "values": [
+        0,
+        1,
+        2,
+      ],
+    },
+    {
+      "config": {
+        "displayNameFromDS": "",
+        "links": [
+          {
+            "targetBlank": true,
+            "title": "Create a Notebook in Lightstep",
+            "url": "https://notebooks",
+          },
+        ],
+      },
+      "labels": {},
+      "name": "Value",
+      "type": "number",
+      "values": [
+        1,
+        7,
+        1,
+      ],
+    },
+  ],
+  "meta": undefined,
+  "name": undefined,
+  "refId": undefined,
+}
+`;

--- a/src/preprocessors/__snapshots__/index.test.js.snap
+++ b/src/preprocessors/__snapshots__/index.test.js.snap
@@ -156,3 +156,44 @@ exports[`preprocesses Timeseries successfully should set displayNameDS with lege
   "refId": undefined,
 }
 `;
+
+exports[`preprocesses Timeseries successfully should work if there are no labels 1`] = `
+{
+  "fields": [
+    {
+      "config": {},
+      "labels": undefined,
+      "name": "Time",
+      "type": "time",
+      "values": [
+        0,
+        1,
+        2,
+      ],
+    },
+    {
+      "config": {
+        "displayNameFromDS": "<undefined>",
+        "links": [
+          {
+            "targetBlank": true,
+            "title": "Create a Notebook in Lightstep",
+            "url": "https://notebooks",
+          },
+        ],
+      },
+      "labels": {},
+      "name": "Value",
+      "type": "number",
+      "values": [
+        1,
+        7,
+        1,
+      ],
+    },
+  ],
+  "meta": undefined,
+  "name": undefined,
+  "refId": undefined,
+}
+`;

--- a/src/preprocessors/index.test.js
+++ b/src/preprocessors/index.test.js
@@ -95,4 +95,24 @@ describe('preprocesses Timeseries successfully', () => {
     const query = { projectName: 'demo', format: '{{operation}}' };
     expect(preprocessData(res, query, 'https://notebooks')).toMatchSnapshot();
   });
+
+  it('should work if there are no labels and no legend', () => {
+    const res = {
+      data: {
+        attributes: {
+          series: [
+            {
+              points: [
+                [0, 1],
+                [1, 7],
+                [2, 1],
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const query = { projectName: 'demo', format: undefined };
+    expect(preprocessData(res, query, 'https://notebooks')).toMatchSnapshot();
+  });
 });

--- a/src/preprocessors/index.test.js
+++ b/src/preprocessors/index.test.js
@@ -75,4 +75,24 @@ describe('preprocesses Timeseries successfully', () => {
     const query = { projectName: 'demo', format: '{{operation}}' };
     expect(preprocessData(res, query, 'https://notebooks')).toMatchSnapshot();
   });
+
+  it('should work if there are no labels', () => {
+    const res = {
+      data: {
+        attributes: {
+          series: [
+            {
+              points: [
+                [0, 1],
+                [1, 7],
+                [2, 1],
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const query = { projectName: 'demo', format: '{{operation}}' };
+    expect(preprocessData(res, query, 'https://notebooks')).toMatchSnapshot();
+  });
 });

--- a/src/preprocessors/index.test.js
+++ b/src/preprocessors/index.test.js
@@ -1,45 +1,78 @@
 import { preprocessData } from './index';
 
-test('preprocesses logs successfully', () => {
-  const logsDataFrame = preprocessData(
-    {
+describe('logs', () => {
+  it('preprocesses successfully', () => {
+    const logsDataFrame = preprocessData(
+      {
+        data: {
+          attributes: {
+            logs: [
+              [
+                1691409972788,
+                {
+                  event: 'one',
+                  severity: 'ErrorSeverity',
+                  tags: {
+                    'http.status_code': 200,
+                    large_batch: true,
+                    trace_id: 'd29a3fa8fb446ec65eb691a3259a541e',
+                  },
+                },
+              ],
+              [
+                1691409971908,
+                {
+                  event: 'two',
+                  severity: 'InfoSeverity',
+                  tags: {
+                    customer: 'hipcore',
+                    large_batch: false,
+                    trace_id: 'd0fa420269652931236c94bc54d2233e',
+                  },
+                  k8s_environment: 'production',
+                  k8s_namespace: 'default',
+                  k8s_pod: 'hipcore-pod',
+                },
+              ],
+            ],
+          },
+        },
+      },
+      { refId: 'a' },
+      ''
+    );
+
+    expect(logsDataFrame.toJSON()).toMatchSnapshot();
+  });
+});
+
+describe('preprocesses Timeseries successfully', () => {
+  it('should set displayNameDS with legend formatter', () => {
+    const res = {
       data: {
         attributes: {
-          logs: [
-            [
-              1691409972788,
-              {
-                event: 'one',
-                severity: 'ErrorSeverity',
-                tags: {
-                  'http.status_code': 200,
-                  large_batch: true,
-                  trace_id: 'd29a3fa8fb446ec65eb691a3259a541e',
-                },
-              },
-            ],
-            [
-              1691409971908,
-              {
-                event: 'two',
-                severity: 'InfoSeverity',
-                tags: {
-                  customer: 'hipcore',
-                  large_batch: false,
-                  trace_id: 'd0fa420269652931236c94bc54d2233e',
-                },
-                k8s_environment: 'production',
-                k8s_namespace: 'default',
-                k8s_pod: 'hipcore-pod',
-              },
-            ],
+          series: [
+            {
+              'group-labels': ['operation=/get'],
+              points: [
+                [0, 1],
+                [1, 7],
+                [2, 1],
+              ],
+            },
+            {
+              'group-labels': ['operation=/load'],
+              points: [
+                [0, 6],
+                [1, 5],
+                [2, 9],
+              ],
+            },
           ],
         },
       },
-    },
-    { refId: 'a' },
-    ''
-  );
-
-  expect(logsDataFrame.toJSON()).toMatchSnapshot();
+    };
+    const query = { projectName: 'demo', format: '{{operation}}' };
+    expect(preprocessData(res, query, 'https://notebooks')).toMatchSnapshot();
+  });
 });

--- a/src/preprocessors/timeseries.test.js
+++ b/src/preprocessors/timeseries.test.js
@@ -52,5 +52,6 @@ describe('transformLabels', () => {
 
   it('no labels', () => {
     expect(transformLabels([])).toEqual({});
+    expect(transformLabels(undefined)).toEqual({});
   });
 });

--- a/src/preprocessors/timeseries.ts
+++ b/src/preprocessors/timeseries.ts
@@ -67,7 +67,7 @@ export function preprocessTimeseries(res: QueryTimeseriesRes, query: LightstepQu
       });
     }
 
-    const labels: Labels = transformLabels(s['group-labels'] || []);
+    const labels: Labels = transformLabels(s['group-labels']);
 
     dataFrameFields.push({
       name: TIME_SERIES_VALUE_FIELD_NAME,
@@ -97,7 +97,7 @@ export function preprocessTimeseries(res: QueryTimeseriesRes, query: LightstepQu
 // --------------------------------------------------------
 // UTILS
 
-export function transformLabels(groupLabels: string[]) {
+export function transformLabels(groupLabels: string[] = []) {
   const labels: Labels = {};
   groupLabels.reduce((acc, l) => {
     const data = l.split('=');
@@ -140,7 +140,7 @@ export function createTimestampMap(timestamps: number[]): Map<number, number> {
 }
 
 // TODO: remove when Grafana 10 is the minimum supported version
-function legenedFormatter(legend: string, labels: Labels) {
+function legenedFormatter(legend = "", labels: Labels) {
   const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
   return legend.replace(aliasRegex, (_, group) => (labels[group] ? labels[group] : "<undefined>"));
 }

--- a/src/preprocessors/timeseries.ts
+++ b/src/preprocessors/timeseries.ts
@@ -1,7 +1,5 @@
 import { Field, FieldType, toDataFrame, Labels, TIME_SERIES_VALUE_FIELD_NAME } from '@grafana/data';
 import { LightstepQuery, QueryTimeseriesRes } from '../types';
-import { template } from 'lodash';
-
 
 /**
  * Response pre-processor that converts the LS response data into Grafana wide
@@ -69,7 +67,7 @@ export function preprocessTimeseries(res: QueryTimeseriesRes, query: LightstepQu
       });
     }
 
-    const labels: Labels = transformLabels(s['group-labels']);
+    const labels: Labels = transformLabels(s['group-labels'] || []);
 
     dataFrameFields.push({
       name: TIME_SERIES_VALUE_FIELD_NAME,
@@ -143,5 +141,6 @@ export function createTimestampMap(timestamps: number[]): Map<number, number> {
 
 // TODO: remove when Grafana 10 is the minimum supported version
 function legenedFormatter(legend: string, labels: Labels) {
-  return template(legend, {interpolate: /{{([\s\S]+?)}}/g})(labels);
+  const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
+  return legend.replace(aliasRegex, (_, group) => (labels[group] ? labels[group] : "<undefined>"));
 }

--- a/src/preprocessors/timeseries.ts
+++ b/src/preprocessors/timeseries.ts
@@ -139,8 +139,9 @@ export function createTimestampMap(timestamps: number[]): Map<number, number> {
   return timestampToIndexMap;
 }
 
-// TODO: remove when Grafana 10 is the minimum supported version
 function legenedFormatter(legend = "", labels: Labels) {
+  // nb: We're slightly divergent from `renderLegendFormat` available in v10+
+  // since they just repeat the key if a label value is undefined
   const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
   return legend.replace(aliasRegex, (_, group) => (labels[group] ? labels[group] : "<undefined>"));
 }

--- a/src/preprocessors/timeseries.ts
+++ b/src/preprocessors/timeseries.ts
@@ -1,6 +1,7 @@
-import { Field, FieldType, MutableDataFrame } from '@grafana/data';
-import { getTemplateSrv } from '@grafana/runtime';
+import { Field, FieldType, toDataFrame, Labels, TIME_SERIES_VALUE_FIELD_NAME } from '@grafana/data';
 import { LightstepQuery, QueryTimeseriesRes } from '../types';
+import { template } from 'lodash';
+
 
 /**
  * Response pre-processor that converts the LS response data into Grafana wide
@@ -26,8 +27,8 @@ import { LightstepQuery, QueryTimeseriesRes } from '../types';
  * ```js
  * [
  *   { name: 'Time', type: FieldType.time, values: [0, 1, 2] },
- *   { name: '{operation="/get"}', type: FieldType.number, values: [1, 7, 1] },
- *   { name: '{operation="/load"}', type: FieldType.number, values: [6, 5, 9] }
+ *   { name: 'Value', type: FieldType.number, values: [1, 7, 1], labels: {operation:"/get"} },
+ *   { name: 'Value', type: FieldType.number, values: [6, 5, 9], labels: {operation:"/load"} }
  * ]
  * ```
  */
@@ -36,7 +37,7 @@ export function preprocessTimeseries(res: QueryTimeseriesRes, query: LightstepQu
 
   // If this is an empty query, bail 👋
   if (!series) {
-    return new MutableDataFrame({
+    return toDataFrame({
       refId: query.refId,
       fields: [],
     });
@@ -68,11 +69,16 @@ export function preprocessTimeseries(res: QueryTimeseriesRes, query: LightstepQu
       });
     }
 
+    const labels: Labels = transformLabels(s['group-labels']);
+
     dataFrameFields.push({
-      name: createFieldName(query.format, query.text, s['group-labels']),
+      name: TIME_SERIES_VALUE_FIELD_NAME,
       type: FieldType.number,
       values,
+      labels: labels,
+
       config: {
+        displayNameFromDS: legenedFormatter(query.format, labels),
         links: [
           {
             url: notebookURL,
@@ -84,7 +90,7 @@ export function preprocessTimeseries(res: QueryTimeseriesRes, query: LightstepQu
     });
   });
 
-  return new MutableDataFrame({
+  return toDataFrame({
     refId: query.refId,
     fields: dataFrameFields,
   });
@@ -93,29 +99,15 @@ export function preprocessTimeseries(res: QueryTimeseriesRes, query: LightstepQu
 // --------------------------------------------------------
 // UTILS
 
-/**
- * Produces a formatted display name for a series
- */
-export function createFieldName(format: string, queryText: string, groupLabels: string[] = []) {
-  let formattedLabels = '';
-
-  if (groupLabels.length > 0) {
-    formattedLabels = `{${groupLabels
-      .sort((a, b) => a.localeCompare(b))
-      // Surround label value in double quotes (e.g. 'key=value' => 'key="value"')
-      .map((labelKeyAndValue) => labelKeyAndValue.replace('=', '="') + '"')
-      .join(', ')}}`;
-  }
-
-  if (format) {
-    return getTemplateSrv().replace(format) + (formattedLabels.length > 0 ? ' ' + formattedLabels : '');
-  }
-
-  if (groupLabels.length > 0) {
-    return formattedLabels;
-  }
-
-  return queryText;
+export function transformLabels(groupLabels: string[]) {
+  const labels: Labels = {};
+  groupLabels.reduce((acc, l) => {
+    const data = l.split('=');
+    // if label value is missing grafana goes defaults to something like "Value 5"
+    acc[data[0]] = data[1] !== '' ? data[1] : '<undefined>';
+    return acc;
+  }, labels);
+  return labels;
 }
 
 /**
@@ -147,4 +139,9 @@ export function createTimestampMap(timestamps: number[]): Map<number, number> {
   }
 
   return timestampToIndexMap;
+}
+
+// TODO: remove when Grafana 10 is the minimum supported version
+function legenedFormatter(legend: string, labels: Labels) {
+  return template(legend, {interpolate: /{{([\s\S]+?)}}/g})(labels);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
+import { DataQuery, DataSourceJsonData } from '@grafana/schema';
 
 /**
  * The complete query definition needed to request data from the Lightstep API.


### PR DESCRIPTION
## What does this PR do?

Adds a legend formatter so folks can add custom labels that are derived from the data source.

## How does this impact users?

If a user doesn't use a query name, than there is no change.
If a user adds a query name with a label name reference from the query results, like`{{service}}`, then the legend for the that value is interpolated with the label value.

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/932f7d05-ce16-4bb0-b7ba-6b174a0fc559">


## What needed to change in the code and why?

A few changes were made to the Time Series Value fields:

* Labels are appended to the field it self. This will use default formatting and removes the need for our `createFieldName` function. 
* Name is changed to use the `TIME_SERIES_VALUE_FIELD` which has logic to remove the name if there is no `displayNameFromDS` set and use default label formatting.
* Query Name allows for variable names in simple mustache like syntax `{{var1}}` which is similar to the Prometheus / Loki datasource
* If an attribute value doesn't exist in the results set, then the value will be set to `<undefined>`

## How did you test this?

New unit tests and manually. 

