### PR TITLE
Chained variables

### DIFF
--- a/src/components/VariableEditor/VariableEditor.tsx
+++ b/src/components/VariableEditor/VariableEditor.tsx
@@ -125,6 +125,7 @@ export class VariableEditor extends CustomVariableSupport<VariableDataSource> {
             <AsyncSelect
               defaultOptions
               cacheOptions
+              allowCustomValue={true}
               defaultValue={query ? { label: query.attributeKey, value: query.attributeKey } : undefined}
               loadOptions={loadOptions}
               onChange={(v) => {

--- a/src/components/VariableEditor/VariableEditor.tsx
+++ b/src/components/VariableEditor/VariableEditor.tsx
@@ -10,7 +10,7 @@ import {
   QueryEditorProps,
   SelectableValue,
 } from '@grafana/data';
-import { Observable, from , map} from 'rxjs';
+import { Observable} from 'rxjs';
 import invariant from 'tiny-invariant';
 import { createRequestVariables } from 'datasource';
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -4,6 +4,7 @@ import {
   DataSourceApi,
   DataSourceInstanceSettings,
   rangeUtil,
+  ScopedVars
 } from '@grafana/data';
 import { config, getBackendSrv, getTemplateSrv } from '@grafana/runtime';
 import { preprocessData } from './preprocessors';
@@ -61,6 +62,7 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
       const notebookURL = createNotebookURL(request, visibleTargets, projectName);
 
       const requests = visibleTargets.map(async (query) => {
+
         const res = await getBackendSrv().post(`${this.url}/projects/${query.projectName}/telemetry/query_timeseries`, {
           data: {
             attributes: {
@@ -70,7 +72,7 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
               'youngest-time': request.range.to,
               // query_timeseries minimum supported output-period is 1 second
               'output-period': Math.max(1, rangeUtil.intervalToSeconds(request.interval)),
-              'template-variables': createRequestVariables(),
+              'template-variables': createRequestVariables(request.scopedVars),
             },
             analytics: {
               anonymized_user: hashedEmail,
@@ -150,7 +152,7 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
  * Translates Grafana dashboard variables into a set of LS API template
  * variables
  */
-export function createRequestVariables() {
+export function createRequestVariables(scopedVars: ScopedVars) {
   return getTemplateSrv()
     .getVariables()
     .map((v) => {
@@ -161,6 +163,16 @@ export function createRequestVariables() {
         let values = Array.isArray(value) ? value : [value];
         if (values.length === 1 && values[0] === '$__all') {
           values = [];
+        }
+
+        // check if there are scopedVars in the request
+        // that will override the template variable
+        // nb: Panel options like Repeat will set scopedVars based on the selected template variable
+        if (scopedVars && scopedVars?.[v.name]) {
+          const scopedVar = scopedVars[v.name]?.text ?? "";
+          if (scopedVar !== "") {
+            values = [scopedVar]
+          }
         }
 
         return {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -150,7 +150,7 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
  * Translates Grafana dashboard variables into a set of LS API template
  * variables
  */
-function createRequestVariables() {
+export function createRequestVariables() {
   return getTemplateSrv()
     .getVariables()
     .map((v) => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -152,7 +152,7 @@ export class DataSource extends DataSourceApi<LightstepQuery, LightstepDataSourc
  * Translates Grafana dashboard variables into a set of LS API template
  * variables
  */
-export function createRequestVariables(scopedVars: ScopedVars) {
+export function createRequestVariables(scopedVars?: ScopedVars) {
   return getTemplateSrv()
     .getVariables()
     .map((v) => {

--- a/src/preprocessors/__snapshots__/index.test.js.snap
+++ b/src/preprocessors/__snapshots__/index.test.js.snap
@@ -97,7 +97,6 @@ exports[`preprocesses Timeseries successfully should set displayNameDS with lege
   "fields": [
     {
       "config": {},
-      "labels": undefined,
       "name": "Time",
       "type": "time",
       "values": [
@@ -151,8 +150,7 @@ exports[`preprocesses Timeseries successfully should set displayNameDS with lege
       ],
     },
   ],
-  "meta": undefined,
-  "name": undefined,
+  "length": 3,
   "refId": undefined,
 }
 `;
@@ -162,7 +160,6 @@ exports[`preprocesses Timeseries successfully should work if there are no labels
   "fields": [
     {
       "config": {},
-      "labels": undefined,
       "name": "Time",
       "type": "time",
       "values": [
@@ -192,8 +189,7 @@ exports[`preprocesses Timeseries successfully should work if there are no labels
       ],
     },
   ],
-  "meta": undefined,
-  "name": undefined,
+  "length": 3,
   "refId": undefined,
 }
 `;
@@ -203,7 +199,6 @@ exports[`preprocesses Timeseries successfully should work if there are no labels
   "fields": [
     {
       "config": {},
-      "labels": undefined,
       "name": "Time",
       "type": "time",
       "values": [
@@ -233,8 +228,7 @@ exports[`preprocesses Timeseries successfully should work if there are no labels
       ],
     },
   ],
-  "meta": undefined,
-  "name": undefined,
+  "length": 3,
   "refId": undefined,
 }
 `;


### PR DESCRIPTION
## What does this PR do?

- Adds support for chained template variables. 
- Allows for scopedVariables to override template variables when a panel has a repeat option set

![image](https://github.com/user-attachments/assets/88fd9b8f-1342-416a-82de-d56776d15843)


## How does this impact users?

Users can now create template variables with UQL filter expressions. Those filter expressions can have template variables as well.

For example, when a service variable exists and we're defining an operation variable we can make it dependent on the service variable with the following UQL filter expression:

```
service == $service
```

This will then scope the operation values to the value(s) in $service 

## What needed to change in the code and why?

- Introduced a new form element for updating the scope expression
- When requesting attributes values, we'll always serialize the template variables like we do when querying.

## How did you test this?

Manual
